### PR TITLE
verify develocity has been set in the root project

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "8.8.0"
 kotlin = "2.1.0"
 coreKtx = "1.15.0"
-develocity = "3.19"
+develocity = "3.19.1"
 junit = "4.13.2"
 junitVersion = "1.2.1"
 ktlint = "12.1.2"

--- a/plugin/build-scan-artifact-size-reporter/build.gradle.kts
+++ b/plugin/build-scan-artifact-size-reporter/build.gradle.kts
@@ -6,11 +6,11 @@ plugins {
     alias(libs.plugins.gradle.publish)
 }
 
-version = "0.1.0"
+version = "0.1.1"
 group = "io.github.cdsap"
 dependencies {
     compileOnly(libs.android.tools)
-    compileOnly(libs.develocity)
+    implementation(libs.develocity)
 }
 gradlePlugin {
     website = "https://github.com/cdsap/BuildScanArtifactSizeReporter"

--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/AndroidArtifactsInfoPlugin.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/AndroidArtifactsInfoPlugin.kt
@@ -2,19 +2,23 @@ package io.github.cdsap.agp.artifacts
 
 import com.android.build.gradle.AppPlugin
 import com.android.build.gradle.LibraryPlugin
+import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
 class AndroidArtifactsInfoPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        with(project) {
-            plugins.withType(AppPlugin::class.java) {
-                configureAndroidApplication()
+        val rootProject = project.gradle.rootProject
+        if (rootProject.extensions.findByType(DevelocityConfiguration::class.java) != null) {
+            with(project) {
+                plugins.withType(AppPlugin::class.java) {
+                    configureAndroidApplication()
+                }
+                plugins.withType(LibraryPlugin::class.java) {
+                    configureAndroidLibrary()
+                }
+                onBuildFinished(Output.Constants.OUTPUT)
             }
-            plugins.withType(LibraryPlugin::class.java) {
-                configureAndroidLibrary()
-            }
-            onBuildFinished(Output.Constants.OUTPUT)
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -13,7 +13,7 @@ pluginManagement {
     }
 }
 plugins {
-    id("com.gradle.develocity") version "3.19"
+    id("com.gradle.develocity") version "3.19.1"
 }
 develocity {
     server = "https://ge.solutions-team.gradle.com/"


### PR DESCRIPTION
If the project is not using Develocity the build thrown:
```
Caused by: java.lang.ClassNotFoundException: com.gradle.develocity.agent.gradle.DevelocityConfiguration
```

Changing to implementation the dependency and checking if dv has been applied