### PR TITLE
fix: refactor artifact size output writing to a shared helper

### DIFF
--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriter.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriter.kt
@@ -1,0 +1,19 @@
+package io.github.cdsap.agp.artifacts.tasks
+
+import java.io.File
+
+internal object ArtifactSizeOutputWriter {
+    fun write(
+        outputDirectory: File,
+        artifacts: Iterable<File>,
+    ) {
+        outputDirectory.deleteRecursively()
+        outputDirectory.mkdirs()
+        artifacts.forEach { artifact ->
+            if (artifact.exists()) {
+                val markerName = "${artifact.name}.size"
+                File(outputDirectory, markerName).writeText(artifact.length().toString())
+            }
+        }
+    }
+}

--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeApkTask.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeApkTask.kt
@@ -25,22 +25,13 @@ abstract class SizeApkTask : DefaultTask() {
 
     @TaskAction
     fun taskAction() {
-        val outputDirectory = output.get()
-        val outputFile = outputDirectory.asFile
-        outputFile.deleteRecursively()
-        outputFile.mkdirs()
-
         val builtArtifacts =
             builtArtifactsLoader.get().load(input.get())
                 ?: throw RuntimeException("Cannot load APKs")
 
-        builtArtifacts.elements.forEach { artifact ->
-            if (File(artifact.outputFile).exists()) {
-                val fileName = "${artifact.outputFile.substringAfterLast("/")}.size"
-                outputDirectory.file(fileName).asFile.writeText(
-                    File(artifact.outputFile).length().toString(),
-                )
-            }
-        }
+        ArtifactSizeOutputWriter.write(
+            output.get().asFile,
+            builtArtifacts.elements.map { File(it.outputFile) },
+        )
     }
 }

--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeFileTask.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeFileTask.kt
@@ -19,14 +19,9 @@ abstract class SizeFileTask : DefaultTask() {
 
     @TaskAction
     fun taskAction() {
-        val outputDirectory = output.get()
-        val outputFile = outputDirectory.asFile
-        outputFile.deleteRecursively()
-        outputFile.mkdirs()
-        val file = input.get().asFile
-        if (file.exists()) {
-            val fileName = "${file.name.substringAfterLast("/")}.size"
-            outputDirectory.file(fileName).asFile.writeText(file.length().toString())
-        }
+        ArtifactSizeOutputWriter.write(
+            output.get().asFile,
+            listOf(input.get().asFile),
+        )
     }
 }

--- a/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriterTest.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriterTest.kt
@@ -1,0 +1,78 @@
+package io.github.cdsap.agp.artifacts.tasks
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ArtifactSizeOutputWriterTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun writesMarkerNamedAfterArtifactWithByteLength() {
+        val outputDir = tempFolder.newFolder("output")
+        val artifact = tempFolder.newFile("app-debug.apk")
+        artifact.writeBytes(ByteArray(42) { 1 })
+
+        ArtifactSizeOutputWriter.write(outputDir, listOf(artifact))
+
+        val marker = File(outputDir, "app-debug.apk.size")
+        assertTrue(marker.exists())
+        assertEquals("42", marker.readText())
+    }
+
+    @Test
+    fun writesMarkersForMultipleArtifacts() {
+        val outputDir = tempFolder.newFolder("output")
+        val apk = tempFolder.newFile("app-debug.apk").also { it.writeBytes(ByteArray(10)) }
+        val aab = tempFolder.newFile("app-release.aab").also { it.writeBytes(ByteArray(25)) }
+
+        ArtifactSizeOutputWriter.write(outputDir, listOf(apk, aab))
+
+        assertEquals("10", File(outputDir, "app-debug.apk.size").readText())
+        assertEquals("25", File(outputDir, "app-release.aab.size").readText())
+    }
+
+    @Test
+    fun skipsMissingArtifactFiles() {
+        val outputDir = tempFolder.newFolder("output")
+        val existing = tempFolder.newFile("present.apk").also { it.writeBytes(ByteArray(7)) }
+        val missing = File(tempFolder.root, "absent.apk")
+
+        ArtifactSizeOutputWriter.write(outputDir, listOf(existing, missing))
+
+        assertTrue(File(outputDir, "present.apk.size").exists())
+        assertFalse(File(outputDir, "absent.apk.size").exists())
+    }
+
+    @Test
+    fun deletesAndRecreatesOutputDirectoryBeforeWriting() {
+        val outputDir = tempFolder.newFolder("output")
+        val stale = File(outputDir, "stale.size").also { it.writeText("old") }
+        val nested = File(outputDir, "nested").also { it.mkdirs() }
+        File(nested, "leftover.txt").writeText("gone")
+        val artifact = tempFolder.newFile("fresh.apk").also { it.writeBytes(ByteArray(3)) }
+
+        ArtifactSizeOutputWriter.write(outputDir, listOf(artifact))
+
+        assertFalse(stale.exists())
+        assertFalse(nested.exists())
+        assertEquals("3", File(outputDir, "fresh.apk.size").readText())
+    }
+
+    @Test
+    fun usesArtifactFileNameForMarkerEvenWhenPathContainsDirectories() {
+        val nested = tempFolder.newFolder("build", "outputs")
+        val artifact = File(nested, "module.apk").also { it.writeBytes(ByteArray(5)) }
+        val outputDir = tempFolder.newFolder("output")
+
+        ArtifactSizeOutputWriter.write(outputDir, listOf(artifact))
+
+        assertEquals("5", File(outputDir, "module.apk.size").readText())
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeApkTask.kt` and `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeFileTask.kt` both own the same output-side behavior: delete and recreate the size output directory, check artifact file existence, derive a `<artifact-name>.size` marker name, and write the byte length. This duplicates core artifact-size reporting logic inside Gradle task infrastructure classes.

### Why this matters

The plugin's central behavior is producing size marker files for Android artifacts, but that behavior is currently spread across task implementations. Any future change to marker naming, missing-file handling, or output cleanup has to be made consistently in multiple Gradle task classes, which raises maintenance cost and makes focused unit testing harder.

### Proposed change

Extract the shared marker-writing behavior into a small internal helper, for example `ArtifactSizeOutputWriter`, that accepts an output directory and one or more artifact files. Keep `SizeFileTask` and `SizeApkTask` responsible for Gradle inputs, AGP artifact loading, and task wiring, then delegate directory cleanup and `.size` file creation to the helper. Preserve the existing marker file names and byte values.

### Notes

Clean architecture lens: Gradle task classes are infrastructure adapters, while artifact-size marker creation is the plugin's core behavior. Extracting this tiny helper clarifies that boundary without changing the repository structure or introducing a broader domain model.

Fixes #14

## Changes

- `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriter.kt`
- `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeApkTask.kt`
- `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/tasks/SizeFileTask.kt`
- `plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/tasks/ArtifactSizeOutputWriterTest.kt`

## Verification

- `./gradlew build`
