### PR TITLE
fix: declare plugin portal configuration-cache compatibility (and prove

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,25 @@ on:
   pull_request:
 
 jobs:
+  plugin_tests:
+    name: "Plugin unit and configuration-cache tests"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: 21
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Run plugin tests
+        run: ./gradlew -p plugin :build-scan-artifact-size-reporter:test
+
   build_check:
     name: "Build and verify custom values are included"
     runs-on: ubuntu-latest

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,7 @@ ktlint = "12.1.2"
 espressoCore = "3.6.1"
 appcompat = "1.7.0"
 material = "1.12.0"
-publishing = "1.2.1"
+publishing = "2.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/plugin/build-scan-artifact-size-reporter/build.gradle.kts
+++ b/plugin/build-scan-artifact-size-reporter/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.gradle.plugin.compatibility.compatibility
+
 plugins {
     `java-gradle-plugin`
     `kotlin-dsl`
@@ -14,6 +16,12 @@ dependencies {
     compileOnly(libs.develocity)
     testImplementation("junit:junit:4.13.2")
 }
+
+tasks.test {
+    maxHeapSize = "1g"
+    jvmArgs("-XX:MaxMetaspaceSize=512m")
+}
+
 gradlePlugin {
     website = "https://github.com/cdsap/BuildScanArtifactSizeReporter"
     vcsUrl = "https://github.com/cdsap/BuildScanArtifactSizeReporter.git"
@@ -24,6 +32,11 @@ gradlePlugin {
             displayName = "Android Artifacts Size Report"
             description = "Extends Build Scans by adding custom values with the artifacts size of Android projects"
             tags = listOf("build scans", "android")
+            compatibility {
+                features {
+                    configurationCache = true
+                }
+            }
         }
     }
 }

--- a/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ConfigurationCacheE2ETest.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ConfigurationCacheE2ETest.kt
@@ -5,69 +5,68 @@ import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
-import org.junit.runner.RunWith
-import org.junit.runners.Parameterized
 
-@RunWith(Parameterized::class)
-class ProjectIsolationE2ETest(private val develocityVersion: String) {
-    companion object {
-        @JvmStatic
-        @Parameterized.Parameters(name = "develocityVersion={0}")
-        fun versions() = listOf("4.2.2", "4.1", "3.19.2")
-    }
-
+/**
+ * Proves the published plugin ID works with Configuration Cache so the Plugin Portal
+ * compatibility declaration (`configurationCache = true`) matches reality.
+ */
+class ConfigurationCacheE2ETest {
     @Rule
     @JvmField
     val testProjectDir = TemporaryFolder()
 
     @Test
-    fun testPluginIsCompatibleWithConfigurationCacheWithoutGradleEnterprise() {
+    fun publishedPluginIdIsCompatibleWithConfigurationCache() {
         createKotlinClass()
         createAppModule()
-        createBuildGradle(develocityVersion)
+        createBuildFiles()
 
-        val firstBuild =
+        val runner =
             GradleRunner
                 .create()
                 .withProjectDir(testProjectDir.root)
-                .withArguments(
-                    ":app:assembleDebug",
-                    "-Dkotlin.internal.collectFUSMetrics=false",
-                    "-Dorg.gradle.unsafe.isolated-projects=true",
-                )
                 .withPluginClasspath()
                 .withGradleVersion("9.2.1")
                 .withDebug(false)
-                .build()
-        println(firstBuild.output)
-        val secondBuild =
-            GradleRunner
-                .create()
-                .withProjectDir(testProjectDir.root)
+
+        val firstBuild =
+            runner
                 .withArguments(
                     ":app:assembleDebug",
-                    "-Dorg.gradle.unsafe.isolated-projects=true",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail",
+                    "-Dkotlin.internal.collectFUSMetrics=false",
                 )
-                .withPluginClasspath()
-                .withGradleVersion("9.2.1")
                 .build()
-        println(secondBuild.output)
-        assertTrue(firstBuild.output.contains("Configuration cache entry stored"))
-        assertTrue(secondBuild.output.contains("Reusing configuration cache."))
+        assertTrue(
+            "first run should store a configuration cache entry",
+            firstBuild.output.contains("Configuration cache entry stored"),
+        )
+
+        val secondBuild =
+            runner
+                .withArguments(
+                    ":app:assembleDebug",
+                    "--configuration-cache",
+                    "--configuration-cache-problems=fail",
+                )
+                .build()
+        assertTrue(
+            "second run should be a configuration cache HIT",
+            secondBuild.output.contains("Reusing configuration cache."),
+        )
     }
 
-    private fun createBuildGradle(develocityVersion: String) {
+    private fun createBuildFiles() {
         testProjectDir.newFile("build.gradle.kts").appendText(
             """
             plugins {
                 id("org.jetbrains.kotlin.android") version "2.2.20" apply false
             }
-            println("alo")
+
             repositories {
                 mavenCentral()
-
             }
-
             """.trimIndent(),
         )
 
@@ -78,12 +77,12 @@ class ProjectIsolationE2ETest(private val develocityVersion: String) {
             android.experimental.enableSourceSetPathsMap=true
             android.experimental.cacheCompileLibResources=true
             android.defaults.buildfeatures.renderscript=false
+            org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
             """.trimIndent(),
         )
 
         testProjectDir.newFile("settings.gradle.kts").appendText(
             """
-
             pluginManagement {
                 repositories {
                     google()
@@ -92,22 +91,19 @@ class ProjectIsolationE2ETest(private val develocityVersion: String) {
                 }
             }
             buildscript {
-                    repositories {
-                        google()
-                        mavenCentral()
-
-                    }
-                    dependencies {
-                        classpath ("com.android.tools.build:gradle:8.13.1")
-
-                    }
+                repositories {
+                    google()
+                    mavenCentral()
                 }
+                dependencies {
+                    classpath("com.android.tools.build:gradle:8.13.1")
+                }
+            }
             plugins {
-                id ("com.gradle.develocity") version "$develocityVersion"
+                id("com.gradle.develocity") version "4.2.2"
             }
             develocity {
                 server = "https://ge.solutions-team.gradle.com/"
-
             }
 
             include(":app")
@@ -157,29 +153,24 @@ class ProjectIsolationE2ETest(private val develocityVersion: String) {
                     targetCompatibility = JavaVersion.VERSION_21
                 }
             }
-
-            dependencies {
-
-            }
-        """.trimIndent()
+            """.trimIndent(),
         )
 
         testProjectDir.newFile("app/src/main/AndroidManifest.xml").appendText(
             """
             <?xml version="1.0" encoding="utf-8"?>
-                <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-                    xmlns:tools="http://schemas.android.com/tools">
+            <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools">
 
-                    <application
-                        android:allowBackup="true"
-                        android:label="2"
-                        android:supportsRtl="true"
-                        tools:targetApi="31" />
+                <application
+                    android:allowBackup="true"
+                    android:label="2"
+                    android:supportsRtl="true"
+                    tools:targetApi="31" />
 
-                </manifest>
-            """.trimIndent()
+            </manifest>
+            """.trimIndent(),
         )
-
     }
 
     private fun createKotlinClass() {
@@ -187,12 +178,12 @@ class ProjectIsolationE2ETest(private val develocityVersion: String) {
         testProjectDir.newFile("app/src/main/kotlin/com/example/Hello.kt").appendText(
             """
             package com.example
-        class Hello() {
-            fun print() {
-                println("hello")
+            class Hello() {
+                fun print() {
+                    println("hello")
+                }
             }
-        }
-        """.trimIndent(),
+            """.trimIndent(),
         )
     }
 }


### PR DESCRIPTION
## Summary

### Notes

Related Gradle docs: https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:plugins

Fixes #17

## Changes

- `.github/workflows/build.yaml`
- `gradle/libs.versions.toml`
- `plugin/build-scan-artifact-size-reporter/build.gradle.kts`
- `plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ConfigurationCacheE2ETest.kt`
- `plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ProjectIsolationE2ETest.kt`

## Verification

- `./gradlew build`
