### PR TITLE
fix: add renovate dependency updates (align with projectgenerator)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "packageRules": [
+    {
+      "matchDatasources": ["maven"],
+      "registryUrls": [
+        "https://dl.google.com/dl/android/maven2/",
+        "https://plugins.gradle.org/m2/",
+        "https://repo1.maven.org/maven2/"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "automergeStrategy": "merge-commit"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

### Proposed change

1. Add `.github/renovate.json` (preferred location, same as ProjectGenerator).
2. Start from `extends: [\"config:base\"]`.
3. Enable sensible automerge for safe patch/minor updates where CI is trusted (match ProjectGenerator’s maven automerge pattern when applicable).
4. Include GitHub Actions datasource updates.
5. Ensure Renovate is enabled for the repo in the GitHub Renovate app / Mend dashboard if not already.
6. Open an initial Renovate onboarding PR or first dependency PRs and confirm CI is green.

### Notes

Hermes PR Judge / CI Healer already ignore Renovate authors, so enabling Renovate here should not flood those agents.

Fixes #16

## Changes

- `.github/renovate.json`

## Verification

- `./gradlew build`
