### PR TITLE
fix: refactor build scan publishing to isolate artifact marker collectio

### DIFF
--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisher.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisher.kt
@@ -1,0 +1,19 @@
+package io.github.cdsap.agp.artifacts
+
+import java.io.File
+
+internal object ArtifactSizeBuildScanValuePublisher {
+    fun publish(
+        outputDirectory: File,
+        publishValue: (name: String, value: String) -> Unit,
+    ) {
+        if (outputDirectory.exists()) {
+            outputDirectory.walkTopDown()
+                .filter { it.isFile }
+                .forEach { marker ->
+                    publishValue(marker.name, marker.readText())
+                }
+        }
+        outputDirectory.deleteRecursively()
+    }
+}

--- a/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ProjectExtension.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ProjectExtension.kt
@@ -2,19 +2,15 @@ package io.github.cdsap.agp.artifacts
 
 import com.gradle.develocity.agent.gradle.DevelocityConfiguration
 import org.gradle.api.Project
-import java.io.File
 
 internal fun Project.onBuildFinished(output: String) {
     val projectBuildLayout = this.layout.buildDirectory
     val develocityConfiguration = extensions.findByType(DevelocityConfiguration::class.java)
     develocityConfiguration?.buildScan?.buildFinished {
-        projectBuildLayout.get()
-            .dir(output).asFileTree.files.filterIsInstance<File>()
-            .forEach {
-                develocityConfiguration.buildScan.value(it.name, it.readText())
-            }
-        projectBuildLayout.get()
-            .dir(output).asFile.deleteRecursively()
+        val outputDirectory = projectBuildLayout.get().dir(output).asFile
+        ArtifactSizeBuildScanValuePublisher.publish(outputDirectory) { name, value ->
+            develocityConfiguration.buildScan.value(name, value)
+        }
     }
 }
 

--- a/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisherTest.kt
+++ b/plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisherTest.kt
@@ -1,0 +1,74 @@
+package io.github.cdsap.agp.artifacts
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class ArtifactSizeBuildScanValuePublisherTest {
+    @Rule
+    @JvmField
+    val tempFolder = TemporaryFolder()
+
+    @Test
+    fun publishesMarkerFilesAsNameValuePairsAndDeletesDirectory() {
+        val outputDir = tempFolder.newFolder("markers")
+        File(outputDir, "app-debug.apk.size").writeText("42")
+        File(outputDir, "app-release.aab.size").writeText("100")
+        val published = mutableListOf<Pair<String, String>>()
+
+        ArtifactSizeBuildScanValuePublisher.publish(outputDir) { name, value ->
+            published += name to value
+        }
+
+        assertEquals(
+            setOf("app-debug.apk.size" to "42", "app-release.aab.size" to "100"),
+            published.toSet(),
+        )
+        assertFalse(outputDir.exists())
+    }
+
+    @Test
+    fun publishesNestedMarkerUsingFileNameOnly() {
+        val outputDir = tempFolder.newFolder("markers")
+        val nested = File(outputDir, "nested").also { it.mkdirs() }
+        File(nested, "module.apk.size").writeText("5")
+        val published = mutableListOf<Pair<String, String>>()
+
+        ArtifactSizeBuildScanValuePublisher.publish(outputDir) { name, value ->
+            published += name to value
+        }
+
+        assertEquals(listOf("module.apk.size" to "5"), published)
+        assertFalse(outputDir.exists())
+    }
+
+    @Test
+    fun emptyMarkerDirectoryPublishesNothingAndIsDeleted() {
+        val outputDir = tempFolder.newFolder("markers")
+        val published = mutableListOf<Pair<String, String>>()
+
+        ArtifactSizeBuildScanValuePublisher.publish(outputDir) { name, value ->
+            published += name to value
+        }
+
+        assertTrue(published.isEmpty())
+        assertFalse(outputDir.exists())
+    }
+
+    @Test
+    fun missingMarkerDirectoryPublishesNothing() {
+        val missing = File(tempFolder.root, "does-not-exist")
+        val published = mutableListOf<Pair<String, String>>()
+
+        ArtifactSizeBuildScanValuePublisher.publish(missing) { name, value ->
+            published += name to value
+        }
+
+        assertTrue(published.isEmpty())
+        assertFalse(missing.exists())
+    }
+}


### PR DESCRIPTION
## Summary

### Problem

`plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ProjectExtension.kt` currently mixes Gradle/Develocity wiring with the behavior that reads generated artifact-size marker files and cleans the marker directory. That makes the only path for exercising marker publishing go through `Project`, `DevelocityConfiguration`, and a build-finished callback.

### Why this matters

The plugin already keeps marker writing testable in `ArtifactSizeOutputWriter`, but marker reading/publishing is still coupled to Gradle infrastructure. Small changes to marker naming, filtering, cleanup, or duplicate handling would require heavier integration-style coverage instead of focused unit tests.

### Proposed change

Extract the marker directory processing from `Project.onBuildFinished` into a small internal collaborator, for example `ArtifactSizeBuildScanValuePublisher`, that accepts an output directory and a `(name, value) -> Unit` publishing function. Keep `ProjectExtension.kt` responsible only for locating `DevelocityConfiguration`, registering the build-finished hook, and passing `buildScan.value` into that collaborator.

### Notes

Clean architecture lens: keep Develocity and Gradle callback registration as infrastructure at the edge, and move artifact-size marker publication into a small core service that can be tested without booting Gradle.

Fixes #20

## Changes

- `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisher.kt`
- `plugin/build-scan-artifact-size-reporter/src/main/kotlin/io/github/cdsap/agp/artifacts/ProjectExtension.kt`
- `plugin/build-scan-artifact-size-reporter/src/test/kotlin/io/github/cdsap/agp/artifacts/ArtifactSizeBuildScanValuePublisherTest.kt`

## Verification

- `./gradlew build`
